### PR TITLE
Add API endpoint for top win-loss CTF records

### DIFF
--- a/app/api/.prettierrc
+++ b/app/api/.prettierrc
@@ -1,4 +1,5 @@
 {
   "singleQuote": true,
-  "trailingComma": "all"
+  "trailingComma": "all",
+  "useTabs": true
 }

--- a/app/api/src/common/dto/top-players-query.dto.ts
+++ b/app/api/src/common/dto/top-players-query.dto.ts
@@ -1,9 +1,6 @@
 import { IsOptional, IsPositive, IsNotEmpty, IsIn, Max } from 'class-validator';
 
-const filterableGameTypes = [
-  'CTFGame',
-  'LakRabbitGame'
-] as const;
+const filterableGameTypes = ['CTFGame', 'LakRabbitGame'] as const;
 
 type FilterableGameType = typeof filterableGameTypes[number];
 
@@ -14,12 +11,12 @@ const hitStats = [
 	'laserHitsTG',
 	'laserMATG',
 	'cgHitsTG',
-	'shockHitsTG'
+	'shockHitsTG',
 ] as const;
 
 type Stat = typeof hitStats[number];
 
-export class TopPlayersQueryDto {
+export class TopAccuracyQueryDto {
 	@IsNotEmpty()
 	@IsIn(hitStats as any)
 	stat: Stat;
@@ -35,6 +32,17 @@ export class TopPlayersQueryDto {
 	@IsOptional()
 	@IsPositive()
 	minShots: number;
+
+	@IsOptional()
+	@IsPositive()
+	@Max(100)
+	limit: number;
+}
+
+export class TopWinsQueryDto {
+	@IsOptional()
+	@IsPositive()
+	minGames: number;
 
 	@IsOptional()
 	@IsPositive()

--- a/app/api/src/players/players.controller.ts
+++ b/app/api/src/players/players.controller.ts
@@ -3,7 +3,10 @@ import { ApiOperation } from '@nestjs/swagger';
 
 import { PlayersService } from './players.service';
 import { PaginationQueryDto } from '../common/dto/pagination-query.dto';
-import { TopPlayersQueryDto } from '../common/dto/top-players-query.dto';
+import {
+	TopAccuracyQueryDto,
+	TopWinsQueryDto,
+} from '../common/dto/top-players-query.dto';
 
 @Controller('players')
 export class PlayersController {
@@ -11,7 +14,7 @@ export class PlayersController {
 
 	// /players
 	@Get()
-	@ApiOperation({ tags: [ 'Player' ], summary: 'Return a list of players' })
+	@ApiOperation({ tags: ['Player'], summary: 'Return a list of players' })
 	findAll(@Query() paginationQuery: PaginationQueryDto) {
 		const { limit = 10, offset = 0 } = paginationQuery;
 		return this.playerService.findAll({ limit, offset });
@@ -19,23 +22,36 @@ export class PlayersController {
 
 	@Get('top/accuracy')
 	@ApiOperation({
-		tags: [ 'Player', 'Leaderboard' ],
-		summary: 'Return a leaderboard of players for a specific accuracy stat'
+		tags: ['Player', 'Leaderboard'],
+		summary: 'Return a leaderboard of players for a specific accuracy stat',
 	})
-	findTop(@Query() topPlayersQuery: TopPlayersQueryDto) {
+	findTopAccuracy(@Query() topPlayersQuery: TopAccuracyQueryDto) {
 		const {
 			stat,
 			gameType,
 			minGames = 10,
 			minShots = 100,
-			limit = 10
+			limit = 10,
 		} = topPlayersQuery;
-		return this.playerService.findTop({
+		return this.playerService.findTopAccuracy({
 			stat,
 			gameType,
 			minGames,
 			minShots,
-			limit
+			limit,
+		});
+	}
+
+	@Get('top/wins')
+	@ApiOperation({
+		tags: ['Player', 'Leaderboard'],
+		summary: 'Return a leaderboard of players for win percentage',
+	})
+	findTopWins(@Query() topPlayersQuery: TopWinsQueryDto) {
+		const { minGames = 100, limit = 10 } = topPlayersQuery;
+		return this.playerService.findTopWins({
+			minGames,
+			limit,
 		});
 	}
 }

--- a/app/api/src/players/players.module.ts
+++ b/app/api/src/players/players.module.ts
@@ -9,8 +9,8 @@ import { Players } from './entities/Players';
 import { GameDetail } from '../game/entities/GameDetail';
 
 @Module({
-	imports: [ TypeOrmModule.forFeature([ Players, GameDetail ]), ConfigModule ],
-	providers: [ PlayersService ],
-	controllers: [ PlayersController ]
+	imports: [TypeOrmModule.forFeature([Players, GameDetail]), ConfigModule],
+	providers: [PlayersService],
+	controllers: [PlayersController],
 })
 export class PlayersModule {}


### PR DESCRIPTION
This adds a new `/players/top/wins` endpoint for showing the top [win-loss records (winning percentage)](https://en.wikipedia.org/wiki/Winning_percentage). It only considers normal CTF games currently.

Like the accuracy endpoint, it could probably be optimized to be faster.