### PR TITLE
Use mode() instead of avg() to get most likely teamScoreGame

### DIFF
--- a/app/api/src/players/players.service.ts
+++ b/app/api/src/players/players.service.ts
@@ -287,11 +287,11 @@ export class PlayersService {
 											// enough to determine which team won most of the time, which is all
 											// that matters for this stat.
 											.addSelect(
-												"AVG(CASE WHEN (g.stats->'dtTeamGame'->>0)::integer = 1 THEN (g.stats->'teamScoreGame'->>0)::integer ELSE NULL END)::integer / 100",
+												"(mode() WITHIN GROUP (ORDER BY CASE WHEN (g.stats->'dtTeamGame'->>0)::integer = 1 THEN (g.stats->'teamScoreGame'->>0)::integer ELSE NULL END)) / 100",
 												'score_storm',
 											)
 											.addSelect(
-												"AVG(CASE WHEN (g.stats->'dtTeamGame'->>0)::integer = 2 THEN (g.stats->'teamScoreGame'->>0)::integer ELSE NULL END)::integer / 100",
+												"(mode() WITHIN GROUP (ORDER BY CASE WHEN (g.stats->'dtTeamGame'->>0)::integer = 2 THEN (g.stats->'teamScoreGame'->>0)::integer ELSE NULL END)) / 100",
 												'score_inferno',
 											)
 											.from(GameDetail, 'g')


### PR DESCRIPTION
Since there is a bug in the recorded `teamScoreGame` values, we need to use `mode()` to get the most likely team score from each player (the most common value).

Previously, this was using `avg()` of the team's `teamScoreGame` values and just hoping that it would not change the win/loss result of the match – but it resulted in more `draws` detected than actually happened.

Some example games where this is an issue (check the `teamScoreGame` for each player – when working correctly, each team member should have the same value):

- https://api.playt2.com/game/13091
- https://api.playt2.com/game/12940
