### PR TITLE
Add time period support to leaderboard queries

### DIFF
--- a/app/api/src/common/dto/top-players-query.dto.ts
+++ b/app/api/src/common/dto/top-players-query.dto.ts
@@ -40,6 +40,9 @@ export class TopAccuracyQueryDto {
 	@IsPositive()
 	@Max(100)
 	limit: number;
+
+	@IsOptional()
+	timePeriod: string;
 }
 
 export class TopWinsQueryDto {
@@ -51,4 +54,7 @@ export class TopWinsQueryDto {
 	@IsPositive()
 	@Max(100)
 	limit: number;
+
+	@IsOptional()
+	timePeriod: string;
 }

--- a/app/api/src/players/players.controller.ts
+++ b/app/api/src/players/players.controller.ts
@@ -32,6 +32,7 @@ export class PlayersController {
 			minGames = 10,
 			minShots = 100,
 			limit = 10,
+			timePeriod,
 		} = topPlayersQuery;
 		return this.playerService.findTopAccuracy({
 			stat,
@@ -39,6 +40,7 @@ export class PlayersController {
 			minGames,
 			minShots,
 			limit,
+			timePeriod,
 		});
 	}
 
@@ -48,10 +50,11 @@ export class PlayersController {
 		summary: 'Return a leaderboard of players for win percentage',
 	})
 	findTopWins(@Query() topPlayersQuery: TopWinsQueryDto) {
-		const { minGames = 100, limit = 10 } = topPlayersQuery;
+		const { minGames = 100, limit = 10, timePeriod } = topPlayersQuery;
 		return this.playerService.findTopWins({
 			minGames,
 			limit,
+			timePeriod,
 		});
 	}
 }

--- a/app/api/src/players/players.service.ts
+++ b/app/api/src/players/players.service.ts
@@ -103,7 +103,7 @@ export class PlayersService {
 		// Cast to float to avoid integer division truncating the result.
 		const aggregatedAccuracy = `(${aggregatedHits}::float / ${aggregatedShots}::float)`;
 
-		const sinceDate = '(now() - interval :timePeriod)';
+		const sinceDate = '(now() - (:timePeriod)::interval)';
 
 		// TODO: This whole query could probably be turned into a `ViewEntity` at
 		// some point, but I couldn't get that to work.
@@ -208,7 +208,7 @@ export class PlayersService {
 	async findTopWins(topWinsQuery: TopWinsQueryDto) {
 		const { minGames, limit, timePeriod } = topWinsQuery;
 
-		const sinceDate = '(now() - interval :timePeriod)';
+		const sinceDate = '(now() - (:timePeriod)::interval)';
 
 		const query = this.playersRepository
 			.createQueryBuilder('player')

--- a/app/api/src/players/players.service.ts
+++ b/app/api/src/players/players.service.ts
@@ -56,7 +56,7 @@ export class PlayersService {
 			minGames,
 			minShots,
 			limit,
-			timePeriod,
+			timePeriod = null,
 		} = topAccuracyQuery;
 
 		const shotsStat = {
@@ -206,7 +206,7 @@ export class PlayersService {
 	}
 
 	async findTopWins(topWinsQuery: TopWinsQueryDto) {
-		const { minGames, limit, timePeriod } = topWinsQuery;
+		const { minGames, limit, timePeriod = null } = topWinsQuery;
 
 		const sinceDate = '(now() - (:timePeriod)::interval)';
 

--- a/app/api/src/players/players.service.ts
+++ b/app/api/src/players/players.service.ts
@@ -56,6 +56,7 @@ export class PlayersService {
 			minGames,
 			minShots,
 			limit,
+			timePeriod,
 		} = topAccuracyQuery;
 
 		const shotsStat = {
@@ -102,6 +103,8 @@ export class PlayersService {
 		// Cast to float to avoid integer division truncating the result.
 		const aggregatedAccuracy = `(${aggregatedHits}::float / ${aggregatedShots}::float)`;
 
+		const sinceDate = '(now() - interval :timePeriod)';
+
 		// TODO: This whole query could probably be turned into a `ViewEntity` at
 		// some point, but I couldn't get that to work.
 
@@ -112,6 +115,7 @@ export class PlayersService {
 				shotsStat,
 				minGames,
 				minShots,
+				timePeriod,
 			})
 			.select([
 				'player.player_guid',
@@ -121,6 +125,10 @@ export class PlayersService {
 				'stats.shots',
 				'stats.accuracy',
 			])
+			.addSelect(
+				timePeriod ? sinceDate : 'NULL',
+				'since_date'
+			)
 			.innerJoin(
 				(subQuery) => {
 					let statsQuery = subQuery
@@ -131,6 +139,7 @@ export class PlayersService {
 						.addSelect(aggregatedShots, 'shots')
 						.addSelect(aggregatedAccuracy, 'accuracy')
 						.where(`${shotsValue} > 0`)
+						.andWhere(timePeriod ? `game.datestamp >= ${sinceDate}` : 'TRUE')
 						.groupBy('game.player_guid');
 
 					if (excludeDiscJumps) {
@@ -190,16 +199,20 @@ export class PlayersService {
 			minGames,
 			minShots,
 			limit,
+			timePeriod,
+			sinceDate: rows.length ? rows[0].since_date : null,
 			players,
 		};
 	}
 
 	async findTopWins(topWinsQuery: TopWinsQueryDto) {
-		const { minGames, limit } = topWinsQuery;
+		const { minGames, limit, timePeriod } = topWinsQuery;
+
+		const sinceDate = '(now() - interval :timePeriod)';
 
 		const query = this.playersRepository
 			.createQueryBuilder('player')
-			.setParameters({ minGames })
+			.setParameters({ minGames, timePeriod })
 			.select(['stats.player_name', 'stats.player_guid'])
 			.addSelect('COUNT(stats.game_id)::integer', 'game_count')
 			.addSelect(
@@ -217,6 +230,10 @@ export class PlayersService {
 			.addSelect(
 				"(COUNT(stats.player_match_result = 'win' OR NULL)::float + COUNT(stats.player_match_result = 'draw' OR NULL)::float / 2.0) / COUNT(stats.game_id)::float",
 				'win_percent',
+			)
+			.addSelect(
+				timePeriod ? sinceDate : 'NULL',
+				'since_date'
 			)
 			.innerJoin(
 				(qb) => {
@@ -309,6 +326,8 @@ export class PlayersService {
 							// Each team must have at least 2 players.
 							.andWhere('join_g.team_size_storm >= 2')
 							.andWhere('join_g.team_size_inferno >= 2')
+							// Must fall within the specified time period.
+							.andWhere(timePeriod ? `game.datestamp >= ${sinceDate}` : 'TRUE')
 					);
 				},
 				'stats',
@@ -351,6 +370,8 @@ export class PlayersService {
 			minGames,
 			gameType: ['CTFGame', 'SCtFGame'],
 			limit,
+			timePeriod,
+			sinceDate: rows.length ? rows[0].since_date : null,
 			players,
 		};
 	}


### PR DESCRIPTION
New `timePeriod` param accepts any string that can be cast to PostgresQL's `interval` type and will limit the games to those that fall within the resulting date and the current date.